### PR TITLE
ci: run skipped validation jobs on main

### DIFF
--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -260,7 +260,14 @@ jobs:
 
   update_pr_description:
     name: Update PR Description
-    if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' && github.event.pull_request.user.login != 'dependabot[bot]'
+    if: |
+      always() && (
+        (github.event_name == 'pull_request' &&
+          !github.event.pull_request.head.repo.fork &&
+          github.actor != 'dependabot[bot]' &&
+          github.event.pull_request.user.login != 'dependabot[bot]') ||
+        (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      )
     needs: [ghcr_build_runtime]
     runs-on: ubuntu-22.04
     permissions:
@@ -272,7 +279,12 @@ jobs:
 
       - name: Get short SHA
         id: short_sha
-        run: echo "SHORT_SHA=$(echo ${{ github.event.pull_request.head.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
+        run: echo "SHORT_SHA=${RELEVANT_SHA:0:7}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify runtime build
+        env:
+          RUNTIME_BUILD_RESULT: ${{ needs.ghcr_build_runtime.result }}
+        run: test "$RUNTIME_BUILD_RESULT" = success
 
       - name: Update PR Description
         env:
@@ -282,5 +294,11 @@ jobs:
           SHORT_SHA: ${{ steps.short_sha.outputs.SHORT_SHA }}
         shell: bash
         run: |
-          echo "Updating PR description with Docker and uvx commands"
-          bash ${GITHUB_WORKSPACE}/.github/scripts/update_pr_description.sh
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            echo "Updating PR description with Docker and uvx commands"
+            bash "${GITHUB_WORKSPACE}/.github/scripts/update_pr_description.sh"
+          else
+            echo "No PR context on main; validating the PR description updater script."
+            test -f "${GITHUB_WORKSPACE}/.github/scripts/update_pr_description.sh"
+            bash -n "${GITHUB_WORKSPACE}/.github/scripts/update_pr_description.sh"
+          fi

--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -279,6 +279,8 @@ jobs:
 
       - name: Get short SHA
         id: short_sha
+        env:
+          RELEVANT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         run: echo "SHORT_SHA=${RELEVANT_SHA:0:7}" >> "$GITHUB_OUTPUT"
 
       - name: Verify runtime build

--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -105,7 +105,7 @@ jobs:
 
   coverage-comment:
     name: Coverage Comment
-    if: github.event_name == 'pull_request'
+    if: always() && (github.event_name == 'pull_request' || github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     needs: [test-on-linux, test-enterprise]
 
@@ -115,6 +115,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Verify prerequisite test jobs
+        env:
+          TEST_ON_LINUX_RESULT: ${{ needs.test-on-linux.result }}
+          TEST_ENTERPRISE_RESULT: ${{ needs.test-enterprise.result }}
+        run: |
+          test "$TEST_ON_LINUX_RESULT" = success
+          test "$TEST_ENTERPRISE_RESULT" = success
+
       - uses: actions/download-artifact@v8
         id: download
         with:
@@ -123,7 +131,15 @@ jobs:
 
       - name: Coverage comment
         id: coverage_comment
+        if: github.event_name == 'pull_request'
         uses: py-cov-action/python-coverage-comment-action@v3
         with:
           GITHUB_TOKEN: ${{ github.token }}
           MERGE_COVERAGE_FILES: true
+
+      - name: Validate coverage artifacts on main
+        if: github.event_name == 'push'
+        run: |
+          test -s ".coverage.3.12"
+          test -s ".coverage.runtime.3.12"
+          test -s ".coverage.enterprise.3.12"


### PR DESCRIPTION
## What changed
- Run coverage validation on main using the existing test artifacts.
- Validate the PR-description helper on main without attempting to update a nonexistent PR.
- Preserve the existing PR comment/update behavior.

This removes event-only skips from the fork default-branch CI while keeping the checks safe.

---

To run this PR locally, use the following command:

GUI with Docker:
```
docker run -it --rm   -p 3000:3000   -v /var/run/docker.sock:/var/run/docker.sock   --add-host host.docker.internal:host-gateway   -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.openhands.dev/openhands/runtime:a47ab62-nikolaik   --name openhands-app-a47ab62   docker.openhands.dev/openhands/openhands:a47ab62
```